### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/demoboard/src/main/java/com/onboard/projectboard/domain/UserAccount.java
+++ b/demoboard/src/main/java/com/onboard/projectboard/domain/UserAccount.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/demoboard/src/test/java/com/onboard/projectboard/repository/JpaRepositoryTest.java
+++ b/demoboard/src/test/java/com/onboard/projectboard/repository/JpaRepositoryTest.java
@@ -58,7 +58,7 @@ class JpaRepositoryTest {
 
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("Writer", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newwriter", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
 


### PR DESCRIPTION
회원 id로 로그인하고 유저 식별하므로, 당연히 uk 여야 한다.
이 부분이 설계에서 반영되지 않았던 것을 발견
테스트는 uk 적용으로 기존 `data.sql`의 테스트 데이터와
중복이 발생하므로 `userId` 이름을 수정

This closes #26 